### PR TITLE
allow cgroup for hidraw device

### DIFF
--- a/resolve.sh
+++ b/resolve.sh
@@ -153,6 +153,7 @@ ${CONTAINER_TYPE} run -it \
      --device /dev/nvidia-modeset \
      --device /dev/nvidia-uvm \
      --device /dev/nvidia-uvm-tools \
+     --device-cgroup-rule "c 239:* rwm" \
      --mount type=bind,source=/dev/bus/usb,target=/dev/bus/usb \
      --mount type=bind,source=$XAUTHORITY,target=/tmp/.host_Xauthority,readonly \
      --mount type=bind,source=/etc/localtime,target=/etc/localtime,readonly \


### PR DESCRIPTION
As it stands simply mounting the HIDRAW devices doesn't allow the Speed Editor to work - the Docker container must also have permission to access it.

This adds permissions to all HIDRAW devices (device major number 239) to the container, allowing the Speed Editor (and presumably any other attached HIDRAW panels?  I don't have anything else to test with) to work.
