### PR TITLE
Better fix for adding Speed Editor cgroup

### DIFF
--- a/resolve.sh
+++ b/resolve.sh
@@ -113,7 +113,7 @@ do
 	# probe for Speed Editor, VID/PID is hardcoded
 	DEV=`udevadm info -q property ${f}`
 	if [[ "${DEV}" == *"1EDB:DA0E"* ]]; then
-		echo "Detected Sped Editor on" ${f}
+		echo "Detected Speed Editor on" ${f}
 		eval ${DEV} # udevadm's output looks like variables
 		# note that "eval" could be dangerous if ${DEV} somehow contains something nefarious
 		MOUNTS_HIDRAW="--mount type=bind,source=${f},target=${f} "

--- a/resolve.sh
+++ b/resolve.sh
@@ -153,6 +153,7 @@ ${CONTAINER_TYPE} run -it \
      --device /dev/nvidia-modeset \
      --device /dev/nvidia-uvm \
      --device /dev/nvidia-uvm-tools \
+     --device-cgroup-rule "c 239:* rwm" \
      --mount type=bind,source=/dev/bus/usb,target=/dev/bus/usb \
      --mount type=bind,source=$XAUTHORITY,target=/tmp/.host_Xauthority,readonly \
      --mount type=bind,source=/etc/localtime,target=/etc/localtime,readonly \


### PR DESCRIPTION
Here's a cleaner approach to adding the cgroup. I've used the "blank environment variable" trick you suggested, and use udevadm to probe for the VID and PID of the Speed Editor. Then, I just mount the Speed Editor's /dev/hidraw* device and apply a cgroup rule just for that device.