### PR TITLE
Centos Stream 9:  Pipewire support in container (testers wanted!)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && dnf update -y \
        && dnf install dnf-plugins-core -y \
        && dnf install epel-release -y \
-       && dnf install xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 libXi libXtst procps dbus-x11 libSM libxcrypt-compat pipewire libcurl-devel -y \
+       && dnf install xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 libXi libXtst procps dbus-x11 libSM libxcrypt-compat pipewire libcurl-devel compat-openssl11 -y \
        && curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm -o /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \
        && dnf -y remove pipewire-alsa \
        && rpm -i --nodeps --replacefiles /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && bash /tmp/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run --no-kernel-module --no-kernel-module-source --run-nvidia-xconfig --no-backup --no-questions --ui=none \
        && rm -f /tmp/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run \
        && rm -rf /var/cache/yum/* \
+       && dnf remove -y epel-release dnf-plugins-core libcurl-devel \
        && dnf clean all
 
 ARG USER=resolve

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,16 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && dnf update -y \
        && dnf install dnf-plugins-core -y \
        && dnf install epel-release -y \
-       && dnf install xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 libXi libXtst procps dbus-x11 \
-          libSM libxcrypt-compat pipewire -y \
-       && dnf install libcurl-devel -y \
+       && dnf install xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 libXi libXtst procps dbus-x11 libSM libxcrypt-compat pipewire libcurl-devel -y \
+       && curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm -o /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \
+       && dnf -y remove pipewire-alsa \
+       && rpm -i --nodeps --replacefiles /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \
+       && PINNEDSHA=`/usr/bin/sha256sum /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm` \
+       && if [ "${PINNEDSHA}" != "a870db3bceeeba7f96a9f04265b8c8359629f0bb3066e68464e399d88001ae52  /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm" ]; then echo "bad checksum" ; exit 1; fi \
        && curl https://us.download.nvidia.com/XFree86/Linux-${ARCH}/${NVIDIA_VERSION}/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run -o /tmp/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run \
        && bash /tmp/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run --no-kernel-module --no-kernel-module-source --run-nvidia-xconfig --no-backup --no-questions --ui=none \
        && rm -f /tmp/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run \
        && rm -rf /var/cache/yum/* \
-       && dnf remove -y epel-release dnf-plugins-core \ 
        && dnf clean all
 
 ARG USER=resolve

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && dnf update -y \
        && dnf install dnf-plugins-core -y \
        && dnf install epel-release -y \
-       && dnf install xorg-x11-server-Xorg libXcursor unzip alsa-lib alsa-plugins-pulseaudio librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
+       && dnf install xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 libXi libXtst procps dbus-x11 \
+          libSM libxcrypt-compat pipewire -y \
        && dnf install libcurl-devel -y \
        && curl https://us.download.nvidia.com/XFree86/Linux-${ARCH}/${NVIDIA_VERSION}/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run -o /tmp/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run \
        && bash /tmp/NVIDIA-Linux-${ARCH}-${NVIDIA_VERSION}.run --no-kernel-module --no-kernel-module-source --run-nvidia-xconfig --no-backup --no-questions --ui=none \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && export ARCH=$ARCH \
        && dnf update -y \
        && dnf install dnf-plugins-core xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
-       && echo "nopw - ${NO_PIPEWIRE}" \
        && if [[ "${NO_PIPEWIRE}" == 0 ]] ; then \
              dnf install libXi libXtst procps dbus-x11 libSM libxcrypt-compat pipewire libcurl-devel compat-openssl11 -y \
              && curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm -o /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #     Switch to official CentOS Stream from quay.io
 #     https://www.linux.org/threads/centos-announce-centos-stream-container-images-available-on-quay-io.33339/
 
-ARG BASE_IMAGE=quay.io/centos/centos:stream
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM ${BASE_IMAGE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@
 #     Switch to official CentOS Stream from quay.io
 #     https://www.linux.org/threads/centos-announce-centos-stream-container-images-available-on-quay-io.33339/
 
-FROM quay.io/centos/centos:stream
+ARG BASE_IMAGE=quay.io/centos/centos:stream
+
+FROM ${BASE_IMAGE}
 
 # get the arch and nvidia version from the host.  These are default values overridden in build.sh
 
@@ -29,7 +31,6 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && export ARCH=$ARCH \
        && dnf update -y \
        && dnf install dnf-plugins-core -y \
-       && dnf config-manager --set-enabled powertools \
        && dnf install epel-release -y \
        && dnf install xorg-x11-server-Xorg libXcursor unzip alsa-lib alsa-plugins-pulseaudio librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
        && dnf install libcurl-devel -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM ${BASE_IMAGE}
 # get the arch and nvidia version from the host.  These are default values overridden in build.sh
 
 ARG ARCH=x86_64
-ARG NVIDIA_VERSION=510.47
+ARG NVIDIA_VERSION=510.73
 ARG ZIPNAME
 
 # get x11 + nvidia + sound + other dependency stuff set up the machine ID

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Both Podman and Docker are available in most Linux distributions and can be inst
 
 Sure, why not.  If you have Podman running and prefer that, great.  Or use Docker.  Whatever.
 
-So here's the plan on building the image-- we'll start with the official CentOS 8 Stream, then update the packages and add some dependencies needed for DaVinci Resolve.  Y'know, drivers and libraries and stuff.  Then install DaVinci Resolve from the official zip file you can get from the website.  Then create a user called "resolve" in the CentOS container.  That's the user who will run resolve in CentOS.
+So here's the plan on building the image-- we'll start with the official CentOS Stream, then update the packages and add some dependencies needed for DaVinci Resolve.  Y'know, drivers and libraries and stuff.  Then install DaVinci Resolve from the official zip file you can get from the website.  Then create a user called "resolve" in the CentOS container.  That's the user who will run resolve in CentOS.
 
 ## Wait- a user named "resolve" will run Resolve?  But _I_ want to run it!  How will I access the projects and stuff?
 
@@ -175,7 +175,7 @@ On most Linux systems, you'll need to grant special access to the USB devices, s
 
      **NOTE:  Part of this building/installation process includes agreeing to certain terms and conditions from the makers of DaVinci Resolve [Studio].  Please be sure to review these terms and agree to them before using DaVince Resolve [Studio].  You will be asked to agree when running `./build.sh`.**
 
-7.  Now wait.  The **CentOS 8 Stream** system should be downloaded, updated, dependencies added, the DaVinci Resolve.zip copied in there and everything hopefully will be installed.
+7.  Now wait.  The **CentOS Stream** system should be downloaded, updated, dependencies added, the DaVinci Resolve.zip copied in there and everything hopefully will be installed.
 
     Assuming no errors occur, you're (fingers-crossed) ready to run DaVinci Resolve [Studio] now.
     
@@ -383,7 +383,9 @@ Here are a few environment variables you can set when running `build.sh` and `re
 
 * `RESOLVE_MOUNTS_PATH` -- Set this to a _directory_ where you want the `mounts` folder and its contents to be placed.  The default is right in the repository where `resolve.sh` is running.
 
-* `RESOLVE_BASE_CONTAINER_IMAGE` -- set this to something like "almalinux/8-base" to use a base image other than Centos Stream.  For now, don't use a very new OS such as "almalinux/9-base" that uses pipewire (rather than pulseaudio) as they require a different configuration and additional packages
+* `RESOLVE_BASE_CONTAINER_IMAGE` -- Set this to something like "almalinux/8-base" or "almalinux/9-base" to use a container image other than the Centos Stream 8/9 default.  See `RESOLVE_NO_PIPEWIRE` below to specify if you do not have <a href="https://pipewire.org/">pipewire</a> installed on your host, though the build system will try to auto-detect this.
+
+* `RESOLVE_NO_PIPEWIRE` -- Set this to 1 to tell the build system when you (1) do not have <a href="https://pipewire.org/">pipewire</a> (instead of, say, <a href="https://www.freedesktop.org/wiki/Software/PulseAudio/">Pulseaudio</a>) running on your host or if you are installing a container image that does not easily support Pipewire (such as an image descended from CentOS Stream 8 or earlier).  Set to 0 for a container image that uses Pipewire.  By default, the build system will try to detect a Pipewire-running host (and will consequently default to the CentOS Stream 9 container image), but should falls back to CentOS Stream 8 if Pipewire is not detected.  If you manually override `RESOLVE_BASE_CONTAINER_IMAGE` above, you may need to set `RESOLVE_NO_PIPEWIRE` too, depending on which base container you use.  Ubuntu defaults to using Pipewire starting with 22.10 "Kinetic Kudu", but older Ubuntu can also <a href="https://linuxconfig.org/how-to-install-pipewire-on-ubuntu-linux">install it manually</a>.
 
 * `RESOLVE_TAG` -- You can also set the container tag when building _or_ running.  So if you set `RESOLVE_TAG="17.4.3-TESTING"` when building, you'll end up with an image named **resolve/17.4.3-TESTING**.  With `resolve.sh`, setting this variable will specify the tag you want to run.  The default container tag when building is the Resolve version (also tagged "latest").  The default tag for running is "latest".
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ Here are a few environment variables you can set when running `build.sh` and `re
 
 * `RESOLVE_MOUNTS_PATH` -- Set this to a _directory_ where you want the `mounts` folder and its contents to be placed.  The default is right in the repository where `resolve.sh` is running.
 
+* `RESOLVE_BASE_CONTAINER_IMAGE` -- set this to something like "almalinux/8-base" to use a base image other than Centos Stream.  For now, don't use a very new OS such as "almalinux/9-base" that uses pipewire (rather than pulseaudio) as they require a different configuration and additional packages
+
 * `RESOLVE_TAG` -- You can also set the container tag when building _or_ running.  So if you set `RESOLVE_TAG="17.4.3-TESTING"` when building, you'll end up with an image named **resolve/17.4.3-TESTING**.  With `resolve.sh`, setting this variable will specify the tag you want to run.  The default container tag when building is the Resolve version (also tagged "latest").  The default tag for running is "latest".
 
 * `RESOLVE_LICENSE_AGREE` -- set to "Y" or "YES" if you've already previously agreed to the license and don't want to have to answer the question every time you `./build.sh`.

--- a/build.sh
+++ b/build.sh
@@ -55,12 +55,25 @@ if ! [[ "${RESOLVE_LICENSE_AGREE,,}" =~ ^(y|yes)$ || "${RESOLVE_LICENSES_AGREE,,
     fi
 fi
 
+# if RESOLVE_NO_PIPEWIRE set, use that.  Otherwise check.
+
+if [ ! -z "${RESOLVE_NO_PIPEWIRE}" ]; then
+   export NO_PIPEWIRE=1
+elif `pgrep pipewire &>/dev/null` ; then
+   export NO_PIPEWIRE=0
+else
+   export NO_PIPEWIRE=1
+fi
+
 # allow user to override base container image for this build
+# otherwise pick a default based on whether pipewire is chosen
 
 if [ ! -z "$RESOLVE_BASE_CONTAINER_IMAGE" ]; then
    export BASE_IMAGE="${RESOLVE_BASE_CONTAINER_IMAGE}"
+elif [[ "${NO_PIPEWIRE}" == 1 ]]; then
+   export BASE_IMAGE="quay.io/centos/centos:stream8"
 else
-   export BASE_IMAGE="quay.io/centos/centos:stream"
+   export BASE_IMAGE="quay.io/centos/centos:stream9"
 fi
 
 # allow user to override tag for this build
@@ -85,7 +98,7 @@ fi
 
 echo "Building the resolve:${TAG} image..."
 
-${CONTAINER_BUILD} -t "resolve:${TAG}" -t "resolve" --build-arg ARCH=`uname -m` --build-arg ZIPNAME="${ZIPNAME}" --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg NVIDIA_VERSION="${NVIDIA_VERSION}" --build-arg USER_ID="${USER_ID}"
+${CONTAINER_BUILD} -t "resolve:${TAG}" -t "resolve" --build-arg ARCH=`uname -m` --build-arg ZIPNAME="${ZIPNAME}" --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg NVIDIA_VERSION="${NVIDIA_VERSION}" --build-arg USER_ID="${USER_ID}" --build-arg NO_PIPEWIRE="${NO_PIPEWIRE}"
 
 # remove any context link
 if [ -f "${CONTEXT_ZIP}" ]; then

--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,15 @@ if ! [[ "${RESOLVE_LICENSE_AGREE,,}" =~ ^(y|yes)$ ]]; then
        exit 0
     fi
 fi
+
+# allow user to override base container image for this build
+
+if [ ! -z "$RESOLVE_BASE_CONTAINER_IMAGE" ]; then
+   export BASE_IMAGE="${RESOLVE_BASE_CONTAINER_IMAGE}"
+else
+   export BASE_IMAGE="quay.io/centos/centos:stream"
+fi
+
 # allow user to override tag for this build
 
 if [ ! -z "$RESOLVE_TAG" ]; then
@@ -67,7 +76,7 @@ fi
 
 echo "Building the resolve:${TAG} image..."
 
-${CONTAINER_BUILD} -t "resolve:${TAG}" -t "resolve" --build-arg ARCH=`arch` --build-arg ZIPNAME="${ZIPNAME}" --build-arg NVIDIA_VERSION="${NVIDIA_VERSION}"
+${CONTAINER_BUILD} -t "resolve:${TAG}" -t "resolve" --build-arg ARCH=`arch` --build-arg ZIPNAME="${ZIPNAME}" --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg NVIDIA_VERSION="${NVIDIA_VERSION}"
 
 # remove any context link
 if [ -f "${CONTEXT_ZIP}" ]; then

--- a/resolve.sh
+++ b/resolve.sh
@@ -196,6 +196,7 @@ fi
      --env QT_AUTO_SCREEN_SET_FACTOR=0 \
      --env QT_SCALE_FACTOR=2 \
      --env QT_FONT_DPI=96 \
+     --env XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} \
      --device /dev/dri \
      --device /dev/input \
      --device /dev/nvidia0 \
@@ -203,6 +204,7 @@ fi
      --device /dev/nvidia-modeset \
      --device /dev/nvidia-uvm \
      --device /dev/nvidia-uvm-tools \
+     --mount type=bind,source=${XDG_RUNTIME_DIR}/pipewire-0,target=${XDG_RUNTIME_DIR}/pipewire-0 \
      --mount type=bind,source=/dev/bus/usb,target=/dev/bus/usb \
      --mount type=bind,source=$XAUTHORITY,target=/tmp/.host_Xauthority,readonly \
      --mount type=bind,source=/etc/localtime,target=/etc/localtime,readonly \

--- a/resolve.sh
+++ b/resolve.sh
@@ -208,6 +208,7 @@ fi
      --env PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
      --env PULSE_COOKIE=/run/pulse/cookie \
      --env QT_AUTO_SCREEN_SCALE_FACTOR=1 \
+     --env XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} \
      --device /dev/dri \
      --device /dev/input \
      --device /dev/nvidia0 \


### PR DESCRIPTION
A couple of commits to support [pipewire](https://pipewire.org/) in the container (replacing pulseaudio), which is the default in Centos Stream 9, AlmaLinux 9, Pop!_OS, and most new Linux distributions.

This branch builds Centos Stream 9 by default.  It has only been verified working with the following env set:

`RESOLVE_BASE_CONTAINER_IMAGE=quay.io/centos/centos:stream9`
`RESOLVE_BASE_CONTAINER_IMAGE=almalinux/9-base`

(Tested on Ubuntu 24.04 -- WITH Pipewire (not Pulseaudio) running on the host.)

Note the hack in 2ba43dc to install the deprecated `alsa-plugins-pulseaudio` package instead of `pipewire-alsa`.  This is necessary to fix an apparent pipewire bug with alsa that leads to a 1 second delay on the audio.  The files that get added in this package are `libasound_module_pcm_pulse.so`,  `libasound_module_ctl_pulse.so`, and `libasound_module_conf_pulse.so`, along with some `.conf` files in `/etc/alsa/conf.d`.  Putting them back made this work.  The fix is discussed a bit more [here](https://old.reddit.com/r/davinciresolve/comments/phizng/significant_audio_latency_on_linux/).

This branch does NOT seem to work with Centos 8 Stream.  For one thing, the build breaks until you replace `libxcrypt-compat` with `libxcrypt` and even then, I got no sound.  I haven't really looked into why this is the case.

TESTERS WANTED-- Before this gets merged in, I'd like to know it works on hosts with and without pipewire running.  As this breaks Centos 8, it might be a good idea to either make it *not* do that, or at least be smart about the build so that it always builds a working image whether using pipewire or pulseaudio.