### PR TITLE
fix: Force rendering on dedicated GPU (fixes hybrid GPU setup not working)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ RUN cd /tmp \
     && cat /tmp/squashfs-root/docs/License.txt \
     && rm -rf /tmp/*.run /tmp/squashfs-root /tmp/*.zip /tmp/*.pdf
 
-CMD /opt/resolve/bin/resolve
+CMD __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia __VK_LAYER_NV_optimus=NVIDIA_only /opt/resolve/bin/resolve


### PR DESCRIPTION
This PR presents a fix for those who have both integrated and dedicated (NVIDIA) graphics cards and experience a crash on Resolve's startup with this container setup. I'd like to ask someone to test that the proposed solution does not break Resolve when there's only a single dedicated GPU in the machine. **This PR was tested only on a laptop with a hybrid Intel/NVIDIA GPU setup**.

**TLDR**: Scroll down for the quick fix.

This was tested on Manjaro Linux KDE / NVIDIA drivers 515.48.07  / `pipewire` branch / AlmaLinux 9 base image / DaVinci Resolve 18.0b4

## Background
So even after getting #13 to build and launch properly on Manjaro (on my desktop computer with a single NVIDIA desktop GPU) and I switched to my laptop (it runs Manjaro, too), Resolve closed (crashed) immediately after the welcome window (where I can browse projects) opened. The only possibly relevant log messages I could filter out were these: 

```
0x7f1fc1f42600 | UI.GLContext         | ERROR | 2022-06-17 11:12:38,375 | Not initialized!
0x7f1fc1f42600 | UI.GLContext         | ERROR | 2022-06-17 11:12:38,375 | Failed to make context current.
0x7f1f943f3640 | UI.GLContext         | ERROR | 2022-06-17 11:12:38,456 | Not initialized!
0x7f1f943f3640 | UI.GLContext         | ERROR | 2022-06-17 11:12:38,456 | Failed to make context current.
0x7f1f943f3640 | UI.GLIO              | ERROR | 2022-06-17 11:12:38,456 | MainPlayer: Failed to make OpenGL context current.
0x7f1fc1f42600 | UI.GLIO              | ERROR | 2022-06-17 11:12:38,456 | MainPlayer: Failed to initialize worker thread.
0x7f1eea7d4640 | UI.GLContext         | ERROR | 2022-06-17 11:12:38,456 | Not initialized!
0x7f1eea7d4640 | UI.GLContext         | ERROR | 2022-06-17 11:12:38,457 | Failed to make context current.
0x7f1eea7d4640 | UI.Scopes            | ERROR | 2022-06-17 11:12:38,457 | Failed to make OpenGL context current.
0x7f1fc1f42600 | UI.Scopes            | ERROR | 2022-06-17 11:12:38,457 | Failed to initialize worker thread.
0x7f1fc1f42600 | Main                 | ERROR | 2022-06-17 11:12:38,457 | Failed to initialize OpenGL texture pool, no valid contexts available.
```

Since a Manjaro update was pushed (along with NVIDIA drivers getting bumped from version 510.x to 515.48.07) between me switching from my desktop computer to my laptop (which has both an integrated Intel graphics card and a dedicated NVIDIA card) I first thought that the NVIDIA driver update broke something. Furthermore, running `nvidia-smi` in the container returned info about my NVIDIA graphics card, making the issue even more cryptic. Then, enabling network connectivity in the container resulted in Resolve's welcome screen staying open, but completely freezing, only stopping using `SIGKILL`. The logs contained a variety of the above messages, hinting that Resolve somehow couldn't get an OpenGL context (an error I've seen when programs weren't using the dedicated NVIDIA GPU but instead only the integrated graphics card).

Installing `glx-utils` into the container (and then also `mesa-dri-drivers-x86_64`) using

```
sudo dnf install glx-utils mesa-dri-drivers.x86_64
```
I finally found that the container was still using my integrated GPU:
```
$ glxinfo | grep "OpenGL"
OpenGL vendor string: Intel
OpenGL renderer string: Mesa Intel(R) UHD Graphics 620 (WHL GT2)
OpenGL core profile version string: 4.6 (Core Profile) Mesa 21.3.4
OpenGL core profile shading language version string: 4.60
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile
OpenGL core profile extensions:
OpenGL version string: 4.6 (Compatibility Profile) Mesa 21.3.4
OpenGL shading language version string: 4.60
OpenGL context flags: (none)
OpenGL profile mask: compatibility profile
OpenGL extensions:
OpenGL ES profile version string: OpenGL ES 3.2 Mesa 21.3.4
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
OpenGL ES profile extensions:
```

## Solution
When you are using your laptop, graphics are most likely handled by the integrated (Intel or AMD) graphics card and this seems to be true to programs started _inside_ containers, too! Some programs that require OpenGL only work properly when you start them using `prime-run <program name>` (this tool comes with the proprietary NVIDIA drivers). Now, `prime-run` is not installed into the container, but it's probably doing nothing more than setting environment variables (see [this Ask Ubuntu answer](https://askubuntu.com/a/1368463)). So, to get Resolve to start using the NVIDIA card, inside the container, I did this:

```bash
# enter the container
./resolve.sh /bin/bash

# inside the container, run Resolve using this:
__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia __VK_LAYER_NV_optimus=NVIDIA_only /opt/resolve/bin/resolve
```
and it worked! :sparkles:

## Fixing the container scripts
Now, there are multiple ways to go about starting Resolve on the NVIDIA card without having to manually enter the container and issue the above command. It should suffice to add the following environmental variables to the `CMD` part of the Dockerfile: 

```
CMD __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia __VK_LAYER_NV_optimus=NVIDIA_only /opt/resolve/bin/resolve
```