### PR TITLE
DaVinci Resolve 18.5 support + make rockylinux 8.6 the default distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN if [[ `dnf list libxcrypt-compat` == *libxcrypt-compat* ]]; then export EXTR
        && if [[ `dnf list compat-openssl10` == *compat-openssl10* ]]; then export EXTRA_PACKS="${EXTRA_PACKS} compat-openssl10"; fi \
        && export NVIDIA_VERSION=$NVIDIA_VERSION \
        && export ARCH=$ARCH \
-       && dnf update -y \
+       && dnf update --refresh -y \
        && dnf install dnf-plugins-core xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
        && if [ ! -z "${EXTRA_PACKS}" ]; then dnf install ${EXTRA_PACKS} -y ; fi \
        && if [[ "${NO_PIPEWIRE}" == 0 ]] ; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,10 +83,12 @@ RUN cd /tmp \
 
 COPY ./x264_plugin_patcher.sh /tmp/x264_plugin_patcher.sh
 
+ARG POWERTOOLS=powertools
 RUN if [[ "${BUILD_X264_ENCODER_PLUGIN}" == 1 ]] ; then \
+       if [[ `dnf repolist --all` == *"crb"* ]]; then export POWERTOOLS=crb ; fi \
        cd /tmp \
        && sudo dnf -y install clang llvm zlib-devel git diffutils patch \
-       && sudo dnf -y --enablerepo=crb install nasm \
+       && sudo dnf -y --enablerepo="${POWERTOOLS}" install nasm \
        && git clone https://code.videolan.org/videolan/x264.git \
        && cd x264 \
        && ./configure --enable-shared \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #     Switch to official CentOS Stream from quay.io
 #     https://www.linux.org/threads/centos-announce-centos-stream-container-images-available-on-quay-io.33339/
 
-ARG BASE_IMAGE=docker.io/rockylinux/8.6
+ARG BASE_IMAGE=docker.io/rockylinux:8.6
 
 FROM ${BASE_IMAGE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && dnf install dnf-plugins-core xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
        && if [[ "${NO_PIPEWIRE}" == 0 ]] ; then \
              dnf install libXi libXtst procps dbus-x11 libSM libxcrypt-compat pipewire libcurl-devel compat-openssl11 \
-                 apr apr-util libXinerama libxkbcommon libxkbcommon-x11 libXrandr xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm -y \
+                 apr apr-util libXinerama libxkbcommon libxkbcommon-x11 libXrandr xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm \
+                 libglvnd-opengl pulseaudio-libs -y \
              && curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm -o /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \
              && dnf -y remove pipewire-alsa \
              && rpm -i --nodeps --replacefiles /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ COPY ./x264_plugin_patcher.sh /tmp/x264_plugin_patcher.sh
 ARG POWERTOOLS=powertools
 RUN if [[ "${BUILD_X264_ENCODER_PLUGIN}" == 1 ]] ; then \
        if [[ `dnf repolist --all` == *"crb"* ]]; then export POWERTOOLS=crb ; fi \
-       cd /tmp \
+       && cd /tmp \
        && sudo dnf -y install clang llvm zlib-devel git diffutils patch \
        && sudo dnf -y --enablerepo="${POWERTOOLS}" install nasm \
        && git clone https://code.videolan.org/videolan/x264.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
        && if [[ "${NO_PIPEWIRE}" == 0 ]] ; then \
              dnf install libXi libXtst procps dbus-x11 libSM libxcrypt-compat pipewire libcurl-devel compat-openssl11 \
                  apr apr-util libXinerama libxkbcommon libxkbcommon-x11 libXrandr xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm \
-                 libglvnd-opengl pulseaudio-libs -y \
+                 libglvnd-opengl pulseaudio-libs nss libXcomposite libXdamage -y \
              && curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm -o /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \
              && dnf -y remove pipewire-alsa \
              && rpm -i --nodeps --replacefiles /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,18 @@ ARG BUILD_X264_ENCODER_PLUGIN=0
 #     see https://gitlab.com/WeSuckLess/Reactor/-/blob/master/Docs/Installing-Reactor.md#installing-reactor
 
 # Future: when bluetooth works with speed editor in Linux, add these packages:  bluez avahi dbus-x11 nss-mdns
-
-RUN    export NVIDIA_VERSION=$NVIDIA_VERSION \
+# EXTRA_PACKS are packages that may not be available but should be installed if they are.
+ARG EXTRA_PACKS=""
+RUN if [[ `dnf list libxcrypt-compat` == *libxcrypt-compat* ]]; then export EXTRA_PACKS="${EXTRA_PACKS} libxcrypt-compat" ; fi \
+       && if [[ `dnf list compat-openssl11` == *compat-openssl11* ]]; then export EXTRA_PACKS="${EXTRA_PACKS} compat-openssl11" ; fi \
+       && if [[ `dnf list compat-openssl10` == *compat-openssl10* ]]; then export EXTRA_PACKS="${EXTRA_PACKS} compat-openssl10"; fi \
+       && export NVIDIA_VERSION=$NVIDIA_VERSION \
        && export ARCH=$ARCH \
        && dnf update -y \
        && dnf install dnf-plugins-core xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
+       && if [ ! -z "${EXTRA_PACKS}" ]; then dnf install ${EXTRA_PACKS} -y ; fi \
        && if [[ "${NO_PIPEWIRE}" == 0 ]] ; then \
-             dnf install libXi libXtst procps dbus-x11 libSM libxcrypt-compat pipewire libcurl-devel compat-openssl11 \
+             dnf install libXi libXtst procps dbus-x11 libSM pipewire libcurl-devel \
                  apr apr-util libXinerama libxkbcommon libxkbcommon-x11 libXrandr xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm \
                  libglvnd-opengl pulseaudio-libs nss libXcomposite libXdamage -y \
              && curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm -o /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM ${BASE_IMAGE}
 # get the arch and nvidia version from the host.  These are default values overridden in build.sh
 
 ARG ARCH=x86_64
-ARG NVIDIA_VERSION=510.73
+ARG NVIDIA_VERSION=525.105
 ARG NO_PIPEWIRE=0
 ARG ZIPNAME
 ARG BUILD_X264_ENCODER_PLUGIN=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #     Switch to official CentOS Stream from quay.io
 #     https://www.linux.org/threads/centos-announce-centos-stream-container-images-available-on-quay-io.33339/
 
-ARG BASE_IMAGE=quay.io/centos/centos:stream9
+ARG BASE_IMAGE=docker.io/rockylinux/8.6
 
 FROM ${BASE_IMAGE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ ARG POWERTOOLS=powertools
 RUN if [[ "${BUILD_X264_ENCODER_PLUGIN}" == 1 ]] ; then \
        if [[ `dnf repolist --all` == *"crb"* ]]; then export POWERTOOLS=crb ; fi \
        && cd /tmp \
-       && sudo dnf -y install clang llvm zlib-devel git diffutils patch \
+       && sudo dnf -y install clang llvm zlib-devel git diffutils patch ed \
        && sudo dnf -y --enablerepo="${POWERTOOLS}" install nasm \
        && git clone https://code.videolan.org/videolan/x264.git \
        && cd x264 \
@@ -103,7 +103,7 @@ RUN if [[ "${BUILD_X264_ENCODER_PLUGIN}" == 1 ]] ; then \
        && chmod a+x x264_plugin_patcher.sh \
        && ./x264_plugin_patcher.sh \
        && cd x264_encoder_plugin && make clean && make && make install \
-       && dnf remove -y clang llvm zlib-devel git diffutils patch nasm \
+       && dnf remove -y clang llvm zlib-devel git diffutils patch nasm ed \
        && rm -rf /var/cache/yum/* \
        && dnf clean all ; \
     fi \

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ if [ ! -z "$RESOLVE_BASE_CONTAINER_IMAGE" ]; then
 elif [[ "${NO_PIPEWIRE}" == 1 ]]; then
    export BASE_IMAGE="quay.io/centos/centos:stream8"
 else
-   export BASE_IMAGE="docker.io/rockylinux/8.6"
+   export BASE_IMAGE="docker.io/rockylinux:8.6"
 fi
 
 # allow user to override tag for this build

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ if [ ! -z "$RESOLVE_BASE_CONTAINER_IMAGE" ]; then
 elif [[ "${NO_PIPEWIRE}" == 1 ]]; then
    export BASE_IMAGE="quay.io/centos/centos:stream8"
 else
-   export BASE_IMAGE="quay.io/centos/centos:stream9"
+   export BASE_IMAGE="docker.io/rockylinux/8.6"
 fi
 
 # allow user to override tag for this build


### PR DESCRIPTION
Per issue #33, this PR is meant to support the upcoming 18.5 DaVinci Resolve (DVR) release.

*  Adds new packages required by 18.5 (beta 1)
* Set default linux distribution in the container to Rockylinux 8.6 (which auto-updates to 8.7).  This is BMD's preferred distro.  (If pipewire is unavailable on host, default container linux is not changed from centos stream 8 until someone without pipewire on their host can test rockylinux 8.6 and confirm it works.)
* Add compat-openssl 1.0 for onboarding app in Rockylinux 8.6 (and where supported elsewhere).
* Some packages (compat-openssl 1.0 & 1.1 + libxcrypt-compat) exist on some distributions but not on others, so now checking before installing.
* x264 export plugin build:  Use "crb" package repository when available, "powertools" otherwise
* Update the NVIDIA_VERSION default
* add `--refresh` to `dnf update` command in `Dockerfile` because why not

Tested with:  Rockylinux 8.6, Alma Linux 9.1, and Centos 9 stream w/ DVR 18.5 with both Podman and Docker.  (Hopefully it doesn't break DVR 18.1.)

These changes could probably be more efficient in places, but they seem to work.

Please submit any changes along and/or reports of success/failure.  Thx!
