### PR TITLE
fix build.sh for multi gpu systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ else
 fi
 
 if [ -z "$RESOLVE_NVIDIA_VERSION" ]; then
-   export NVIDIA_VERSION=`nvidia-smi --id-0 --query-gpu=driver_version --format=csv,noheader`
+   export NVIDIA_VERSION=`nvidia-smi --id=0 --query-gpu=driver_version --format=csv,noheader`
 else
    export NVIDIA_VERSION="${RESOLVE_NVIDIA_VERSION}"
 fi

--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ else
 fi
 
 if [ -z "$RESOLVE_NVIDIA_VERSION" ]; then
-   export NVIDIA_VERSION=`nvidia-smi --query-gpu=driver_version --format=csv,noheader`
+   export NVIDIA_VERSION=`nvidia-smi --id-0 --query-gpu=driver_version --format=csv,noheader`
 else
    export NVIDIA_VERSION="${RESOLVE_NVIDIA_VERSION}"
 fi


### PR DESCRIPTION
`nvidia-smi --query-gpu=driver_version` returns one line for each GPU present which breaks build.sh in multi-GPU systems. Only query the primary GPU to determine driver version.