### PR TITLE
Make the nvidia-smi missing a more clear error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,14 +10,14 @@ if [ "$PWD" != "${REPO_DIR}" ]; then
 fi
 
 # is the nvidia-driver installed?
-if lsmod | grep "^nvidia\s" &> /dev/null; then
-   echo "Could not find the Nvidia drivers. Make sure you have them installed."
+if ! command lsmod | grep "^nvidia\s" &> /dev/null; then
+   echo "Could not find the NVIDIA drivers. Make sure you have them installed."
    exit 1
 fi
 
 # Is nvidia-smi installed?
 if ! command -v nvidia-smi &> /dev/null; then
-   echo "Nvidia-smi not found. You may have to install it from a seperate package."
+   echo "nvidia-smi not found. You may have to install it from a separate package."
    exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,14 @@ if [ "$PWD" != "${REPO_DIR}" ]; then
 fi
 
 # is the nvidia-driver installed?
+if lsmod | grep "^nvidia\s" &> /dev/null; then
+   echo "Could not find the Nvidia drivers. Make sure you have them installed."
+   exit 1
+fi
 
+# Is nvidia-smi installed?
 if ! command -v nvidia-smi &> /dev/null; then
-   echo "Nvidia-smi not found. If you know you're using the right drivers make sure you have nvidia-smi installed."
+   echo "Nvidia-smi not found. You may have to install it from a seperate package."
    exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ fi
 # is the nvidia-driver installed?
 
 if ! command -v nvidia-smi &> /dev/null; then
-   echo "Install the nvidia driver and try again."
+   echo "Nvidia-smi not found. If you know you're using the right drivers make sure you have nvidia-smi installed."
    exit 1
 fi
 


### PR DESCRIPTION
A decent amount of distros ship `nvidia-smi` separately from the actual Nvidia driver. If you're using one of those systems than the old error message could be confusing.

I'm not in love with the new message, so I'm down to work on further improvements