### PR TITLE
add libXt for distros that don't include it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN if [[ `dnf list libxcrypt-compat` == *libxcrypt-compat* ]]; then export EXTR
        && dnf install dnf-plugins-core xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
        && if [ ! -z "${EXTRA_PACKS}" ]; then dnf install ${EXTRA_PACKS} -y ; fi \
        && if [[ "${NO_PIPEWIRE}" == 0 ]] ; then \
-             dnf install libXi libXtst procps dbus-x11 libSM pipewire libcurl-devel \
+             dnf install libXi libXt libXtst procps dbus-x11 libSM pipewire libcurl-devel \
                  apr apr-util libXinerama libxkbcommon libxkbcommon-x11 libXrandr xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm \
                  libglvnd-opengl pulseaudio-libs nss libXcomposite libXdamage -y \
              && curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm -o /tmp/alsa-plugins-pulseaudio-1.1.9-1.el8.x86_64.rpm \


### PR DESCRIPTION
Thanks to @CityAplons for reporting this potential issue. Unneeded in Rocky Linux 8.6, but perhaps other distros need it.