### PR TITLE
Add fallback for xauthority on wayland #60

### DIFF
--- a/resolve.sh
+++ b/resolve.sh
@@ -196,6 +196,8 @@ fi
 if [ -z "${XAUTHORITY}" ]; then
    if [ -f "${HOME}/.Xauthority" ]; then
       export XAUTHORITY="${HOME}/.Xauthority"
+   elif [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+      export XAUTHORITY="/dev/null"
    else
       export XAUTHORITY="/run/user/`id -u`/gdm/Xauthority"
    fi


### PR DESCRIPTION
`/gdm/Xauthority` is not always set under Wayland, add `/dev/null` as a fallback.