### PR TITLE
Update installation instructions - NVIDIA container toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,23 +152,25 @@ On most Linux systems, you'll need to grant special access to the USB devices, s
 
 1. On the Linux host, install the latest official proprietary NVIDIA drivers.  In Ubuntu, you can do this in the **Software & Updates** app, in the **Additional Drivers** tab.  Reboot and make sure everything works okay.  I have the computer running in "discrete" mode (set in the BIOS).  Not sure if this is needed.  Also, I am logged in using X11 (Xwindows) in the Desktop.  Not sure how well Wayland will work, although it theoretically *should* be compatible.  (You can switch your desktop from Wayland to X11 in Ubuntu's account login screen.)  Other versions of Linux may have their own method of installing the drivers, so time to [Google that](https://www.google.com/search?q=nvidia+how+to+install+drivers+linux)!
 
-2. Install Podman [or Docker] and and other dependencies with this command (on distributions that support [apt](https://linuxize.com/post/how-to-use-apt-command/):
+2. Install the NVIDIA Container Toolkit using their [guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). This is what allows you to build and run containers leveraging NVIDIA GPUs (it will work with either Podman or Docker)
+
+3. Install Podman [or Docker] and and other dependencies with this command (on distributions that support [apt](https://linuxize.com/post/how-to-use-apt-command/):
      
-    `sudo apt install -y podman fuse-overlayfs nvidia-container-runtime crun`
+    `sudo apt install -y podman fuse-overlayfs crun`
 
     (Alternately, you can `apt install -y docker` instead of podman.  But IMO Podman is better/safer.)
  
-3.  Move or `git clone` [this repository](https://github.com/fat-tire/resolve) (you'll want `Dockerfile`, `resolve.sh`, `build.sh`, `.gitignore`, `.dockerignore`, `env-set.sh`, this `README.md`, etc.) somewhere like `~/containers/resolve`, so let's just go with that for now.
+4.  Move or `git clone` [this repository](https://github.com/fat-tire/resolve) (you'll want `Dockerfile`, `resolve.sh`, `build.sh`, `.gitignore`, `.dockerignore`, `env-set.sh`, this `README.md`, etc.) somewhere like `~/containers/resolve`, so let's just go with that for now.
 
-4. Download the official DaVinci Resolve `.zip` file from [Blackmagic Design](https://www.blackmagicdesign.com), the makers of DaVinci Resolve.
+5. Download the official DaVinci Resolve `.zip` file from [Blackmagic Design](https://www.blackmagicdesign.com), the makers of DaVinci Resolve.
 
-5. Move that `.zip` file to `~/containers/resolve/`and rename it to be in this format:
+6. Move that `.zip` file to `~/containers/resolve/`and rename it to be in this format:
 
       **DaVinci_Resolve_Studio_17.4.2_Linux.zip**
 
      (You can leave out the **_Studio** part if you're using the free version.)
 
-6. Change directory (`cd`) into `~/containers/resolve` and build the resolve container image:
+7. Change directory (`cd`) into `~/containers/resolve` and build the resolve container image:
 
      `cd ~/containers/resolve`
 
@@ -176,13 +178,13 @@ On most Linux systems, you'll need to grant special access to the USB devices, s
 
      **NOTE:  Part of this building/installation process includes agreeing to certain terms and conditions from the makers of DaVinci Resolve [Studio].  Please be sure to review these terms and agree to them before using DaVince Resolve [Studio].  You will be asked to agree when running `./build.sh`.**
 
-7.  Now wait.  The **CentOS Stream** system should be downloaded, updated, dependencies added, the DaVinci Resolve.zip copied in there and everything hopefully will be installed.
+8.  Now wait.  The **CentOS Stream** system should be downloaded, updated, dependencies added, the DaVinci Resolve.zip copied in there and everything hopefully will be installed.
 
     Assuming no errors occur, you're (fingers-crossed) ready to run DaVinci Resolve [Studio] now.
     
     NOTE:  In the future, when NVIDIA releases newer drivers, you'll probably want to keep your CentOS container's drivers "in sync" with the one on the host by rebuilding the container.
 
-8.  To be sure the container's runtime is properly NVIDIA GPU-enabled, try this command:
+9.  To be sure the container's runtime is properly NVIDIA GPU-enabled, try this command:
     
     `./resolve.sh nvidia-smi`
     
@@ -198,7 +200,7 @@ On most Linux systems, you'll need to grant special access to the USB devices, s
     
     This should output an "info box".  If it doesn't, your problem is probably on the host.  If it does show the box, the problem is probably something about the CentOS container image.
 
-9.  Assuming you're good to go, try running Resolve!
+10.  Assuming you're good to go, try running Resolve!
 
     If you run `resolve.sh` as a regular user on the host with:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ On most Linux systems, you'll need to grant special access to the USB devices, s
 
 1. On the Linux host, install the latest official proprietary NVIDIA drivers.  In Ubuntu, you can do this in the **Software & Updates** app, in the **Additional Drivers** tab.  Reboot and make sure everything works okay.  I have the computer running in "discrete" mode (set in the BIOS).  Not sure if this is needed.  Also, I am logged in using X11 (Xwindows) in the Desktop.  Not sure how well Wayland will work, although it theoretically *should* be compatible.  (You can switch your desktop from Wayland to X11 in Ubuntu's account login screen.)  Other versions of Linux may have their own method of installing the drivers, so time to [Google that](https://www.google.com/search?q=nvidia+how+to+install+drivers+linux)!
 
-2. Install the NVIDIA Container Toolkit using their [guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). This is what allows you to build and run containers leveraging NVIDIA GPUs (it will work with either Podman or Docker)
+2. [OPTIONAL] Install the NVIDIA Container Toolkit using their [guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). This is what allows you to build and run containers leveraging NVIDIA GPUs (it will work with either Podman or Docker)
 
 3. Install Podman [or Docker] and and other dependencies with this command (on distributions that support [apt](https://linuxize.com/post/how-to-use-apt-command/):
      


### PR DESCRIPTION
To resolve issue #62 

The NVIDIA container runtime has been deprecated and replaced by `nvidia-container-toolkit`. This has slightly complex installation instructions and requires a link to NVIDIA's guide.