### PR TITLE
support podman build command

### DIFF
--- a/env-set.sh
+++ b/env-set.sh
@@ -15,7 +15,11 @@ fi
 
 if  [ -z "$(podman -v 2>&1 | grep -i 'not found')" ] && [ -z $(echo ${RESOLVE_CONTAINER_ENGINE} | grep -v -i podman) ]; then
    CONTAINER_ENGINE="podman"
-   CONTAINER_BUILD="buildah bud"
+   if command -v buildah 2>&1 > /dev/null; then
+      CONTAINER_BUILD="buildah bud"
+   else
+      CONTAINER_BUILD="podman build ."
+   fi
    CONTAINER_EXISTS="podman image exists"
    CONTAINER_RUN_ARGS=" --annotation run.oci.keep_original_groups=1 --userns=keep-id"
 elif  [ -z "$(docker -v 2>&1 | grep -i 'not found')" ] && [ -n "$(docker -v 2>&1 | grep -i 'version')" ] && [ -z $(echo ${RESOLVE_CONTAINER_ENGINE} | grep -v -i docker) ]; then


### PR DESCRIPTION
I have podman installed but not `buildah`. Running `podman build` works for me. [The documentation](https://docs.podman.io/en/stable/markdown/podman-build.1.html) says
> podman build uses code sourced from the Buildah project

so they should be mostly interchangeable options. I'm not sure what advantage there is to calling `buildah` explicitly but for backwards compatibility my change prefers that if it's installed.