### PR TITLE
mount directories via conf file

### DIFF
--- a/bind_mounts.conf
+++ b/bind_mounts.conf
@@ -1,0 +1,24 @@
+# DaVinci Resolve Bind Mounts Configuration
+#
+# Define which host folders will be accessible inside the Resolve container.
+#
+# USAGE:
+# 1. Set TARGET to the desired mount point inside the container.
+# 2. List absolute or home (~) paths below it.
+# 3. Uncomment and edit as needed.
+
+# Default mount point (do not change)
+TARGET=/opt/resolve/Media
+
+# === ADD YOUR MEDIA FOLDERS BELOW ===
+#/home/user/Videos
+
+
+# === CUSTOM MOUNT POINTS ===
+# To mount elsewhere, define a new TARGET:
+#TARGET=/mnt/CustomFolder
+#/mnt/ExternalDrive/Project
+
+# After adding new paths:
+# - Restart the container
+# - In Resolve: Preferences > Media Storage > Add


### PR DESCRIPTION
Managing custom mounts via `resolve.sh` is cumbersome and unintuitive.  This PR introduces a `bind_mounts.conf` configuration file for simplified container setup, addressing a significant usability issue, especially for editors working externally (e.g., SSD).  

---
Tested on DaVinci Resolve Studio 19.1.3 with Podman on Arch Linux (Gnome 47, Wayland).