### PR TITLE
changes to work with released Davinci Resolve 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN if [[ `dnf list libxcrypt-compat` == *libxcrypt-compat* ]]; then export EXTR
        && export NVIDIA_VERSION=$NVIDIA_VERSION \
        && export ARCH=$ARCH \
        && dnf update --refresh -y \
-       && dnf install dnf-plugins-core xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 -y \
+       && dnf install dnf-plugins-core xorg-x11-server-Xorg libXcursor unzip alsa-lib librsvg2 libGLU sudo module-init-tools libgomp xcb-util python39 mesa-dri-drivers -y \
        && dnf install epel-release -y && dnf install xcb-util-cursor libglvnd-devel -y \
        && if [ ! -z "${EXTRA_PACKS}" ]; then dnf install ${EXTRA_PACKS} -y ; fi \
        && if [[ "${NO_PIPEWIRE}" == 0 ]] ; then \

--- a/README.md
+++ b/README.md
@@ -257,9 +257,17 @@ You can add that line to `.bashrc` (or `~/.zshrc`, etc.) or the `resolve.desktop
 
 ## Can I use a registration code to activate Resolve Studio in the container?
 
-**IMPORTANT NOTICE:  I HAVE NOT TESTED THE DAVINCI RESOLVE STUDIO REGISTRATION CODES-- ONLY THE DONGLES-- FROM INSIDE A CONTAINER.  I DO NOT KNOW HOW THE REGISTRATION CODES WORKS NOR HOW IT WILL HANDLE CONTAINERS.  TRY THIS ENTIRELY AT YOUR OWN RISK!  I AM NOT RESPONSIBLE FOR LOST/WASTED CODES!**
+Yes, you can, if you enable Internet access so Resolve can contact Blackmagic Design's servers:
 
-If you are using Resolve Studio with a registration code, I believe the container should need Internet access so Resolve can contact Blackmagic Design's servers.  I have not tested this functionality in any way, and there may be unforeseen consequences of using a registration code from within a container!
+     RESOLVE_NETWORK=host ./resolve.sh
+
+Your Studio license lets you install the program on two systems, and each container counts as a system.
+If you already have two activations, those will be deleted when you activate the third one, but if you then run DaVinci Resolve Studio on one of the previous systems, it will automatically re-activate.
+
+If you're experimenting with your container configuration, repeatedly creating new containers, you will encounter that situation frequently.
+It appears to always work properly, but the usual disclaimer applies: use at your own risk.
+Ideally you would be able to switch back and forth between multiple containers that share a license, so long as they're on the same computer, under the same account, but that doesn't work.
+It's unclear whether that could be made to work.
 
 For example-- one way a unique machine can be identified in Linux is by looking at the value of `/etc/machine-id`.  Your host has one `machine-id` value, but it seems weird to pass through the _same_ `machine-id` on a container.  So instead I made it so the CentOS container you create will derive its `machine-id` specifically from your host computer's `machine-id` if it exists (without being identical) and store this derived `machine-id` in your `mounts` directory (named appropriately enough, `container-machine-id`).  Using this _should_ make it so that running newly-built images with updated resolve versions would be consistent at least in terms of the `machine-id`.
 
@@ -323,9 +331,13 @@ From what I'm reading, you can even use `--mount` or --[volume](https://docs.doc
 
 ## How do I install the (royalty) free Blackmagic Sound Library?
 
-If you enable the Internet, you should be able to install it right in Resolve, in Fairlight.  However, if you want to download the zip and install it manually without the Internet enabled, here are steps that might work:
+The button in Fairlight to download the sound library launches your web browser to download the file.
+Unfortunately, the container does not have access to the host OS browser, so you have to obtain the file directly from [the Blackmagic Support Center website](https://www.blackmagicdesign.com/ca/support/).
+Search for "sound library" and you'll see "Blackmagic Fairlight Sound Library 1.0" (or newer, if they update it).
+That is the file you need to download.
 
-First, download the .zip fom Blackmagic Design.  Then, start up the container with a shell:
+Once you have downloaded the zip file, here are steps that might work.
+Start up the container with a shell:
 
      ./resolve.sh /bin/bash
 

--- a/resolve.sh
+++ b/resolve.sh
@@ -55,6 +55,8 @@ export RESOLVE_EASYDCP=${MOUNTS_DIRNAME}/easyDCP
 export RESOLVE_LICENSE=${MOUNTS_DIRNAME}/license
 export RESOLVE_COMMON_DATA_DIR=${MOUNTS_DIRNAME}/BlackmagicDesign
 export RESOLVE_MEDIA=${MOUNTS_DIRNAME}/Media  # for raw footage (Ubuntu ~/Videos)
+export RESOLVE_FAIRLIGHT_DIR=${MOUNTS_DIRNAME}/Fairlight
+export RESOLVE_EXTRAS_DIR=${MOUNTS_DIRNAME}/Extras
 
 # make sure expected MOUNTS are here.
 mkdir -p ${RESOLVE_MOUNTS_PATH}/${RESOLVE_HOMEDIR}/.local/share/fonts
@@ -65,6 +67,8 @@ mkdir -p ${RESOLVE_MOUNTS_PATH}/${RESOLVE_EASYDCP}
 mkdir -p ${RESOLVE_MOUNTS_PATH}/${RESOLVE_LICENSE}
 mkdir -p ${RESOLVE_MOUNTS_PATH}/${RESOLVE_COMMON_DATA_DIR}
 mkdir -p ${RESOLVE_MOUNTS_PATH}/${RESOLVE_MEDIA}
+mkdir -p ${RESOLVE_MOUNTS_PATH}/${RESOLVE_FAIRLIGHT_DIR}
+mkdir -p ${RESOLVE_MOUNTS_PATH}/${RESOLVE_EXTRAS_DIR}
 mkdir -p "${HOME}/.local/share/fonts"
 
 # Check for a machine-id file. If one doesn't exist, generate one derived from
@@ -136,6 +140,8 @@ echo "  /opt/resolve/.license                 -> ${RESOLVE_MOUNTS_PATH}/${RESOLV
 echo "  /opt/resolve/'Resolve Disk Database'  -> ${RESOLVE_MOUNTS_PATH}/${RESOLVE_DATABASE}"
 echo "  /var/BlackmagicDesign/DaVinci Resolve -> ${RESOLVE_MOUNTS_PATH}/${RESOLVE_COMMON_DATA_DIR}"
 echo "  /opt/resolve/Media                    -> ${RESOLVE_MOUNTS_PATH}/${RESOLVE_MEDIA}"
+echo "  /opt/resolve/Fairlight                -> ${RESOLVE_MOUNTS_PATH}/${RESOLVE_FAIRLIGHT_DIR}"
+echo "  /opt/resolve/Extras                   -> ${RESOLVE_MOUNTS_PATH}/${RESOLVE_EXTRAS_DIR}"
 
 if [[ "${SRC_CNT}" -ne "0" ]]; then
   echo "${SRC_CNT} extra custom mount(s):"
@@ -204,9 +210,13 @@ if [ -z "${XAUTHORITY}" ]; then
    echo "\$XAUTHORITY was not set.  Defaulting to ${XAUTHORITY}"
 fi
 
+set -x
+
 "${CONTAINER_ENGINE}" run -it \
+      --gpus all --privileged \
      --user resolve:resolve \
      --env DISPLAY=$DISPLAY \
+     --env XAUTHORITY=/tmp/.host_Xauthority \
      --env PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
      --env PULSE_COOKIE=/run/pulse/cookie \
      --env QT_AUTO_SCREEN_SCALE_FACTOR=1 \
@@ -216,8 +226,6 @@ fi
      --env PYTHONPATH="/opt/resolve/Developer/Scripting/Modules/" \
      --device /dev/dri \
      --device /dev/input \
-     --device /dev/nvidia0 \
-     --device /dev/nvidiactl \
      --device /dev/nvidia-modeset \
      --device /dev/nvidia-uvm \
      --device /dev/nvidia-uvm-tools \
@@ -239,6 +247,8 @@ fi
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_COMMON_DATA_DIR},target=/var/BlackmagicDesign \
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_DATABASE},target=/opt/resolve/Resolve\ Disk\ Database \
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_MEDIA},target=/opt/resolve/Media \
+     --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_FAIRLIGHT_DIR},target=/opt/resolve/Fairlight \
+     --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_EXTRAS_DIR},target=/opt/resolve/Extras \
      "${MOUNT_CURSOR_THEME[@]}" \
      "${CGROUP_RULE[@]}" \
      "${MOUNT_SYSTEM_FONTS[@]}" \
@@ -247,6 +257,10 @@ fi
      "${NET_DRIVER}" \
      ${CONTAINER_RUN_ARGS} \
      --rm \
+     --ipc=host \
      --name="resolve_container" \
-     resolve:${RESOLVE_TAG} $*
+     resolve:${RESOLVE_TAG} "$@"
 
+# Removed lines
+#     --device /dev/nvidia0 \
+#     --device /dev/nvidiactl \

--- a/resolve.sh
+++ b/resolve.sh
@@ -213,7 +213,7 @@ fi
 set -x
 
 "${CONTAINER_ENGINE}" run -it \
-      --gpus all --privileged \
+      --gpus all \
      --user resolve:resolve \
      --env DISPLAY=$DISPLAY \
      --env XAUTHORITY=/tmp/.host_Xauthority \
@@ -257,6 +257,5 @@ set -x
      "${NET_DRIVER}" \
      ${CONTAINER_RUN_ARGS} \
      --rm \
-     --ipc=host \
      --name="resolve_container" \
      resolve:${RESOLVE_TAG} "$@"

--- a/resolve.sh
+++ b/resolve.sh
@@ -213,7 +213,6 @@ fi
 set -x
 
 "${CONTAINER_ENGINE}" run -it \
-      --gpus all \
      --user resolve:resolve \
      --env DISPLAY=$DISPLAY \
      --env XAUTHORITY=/tmp/.host_Xauthority \
@@ -226,6 +225,8 @@ set -x
      --env PYTHONPATH="/opt/resolve/Developer/Scripting/Modules/" \
      --device /dev/dri \
      --device /dev/input \
+     --device /dev/nvidia0 \
+     --device /dev/nvidiactl \
      --device /dev/nvidia-modeset \
      --device /dev/nvidia-uvm \
      --device /dev/nvidia-uvm-tools \
@@ -249,6 +250,7 @@ set -x
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_MEDIA},target=/opt/resolve/Media \
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_FAIRLIGHT_DIR},target=/opt/resolve/Fairlight \
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_EXTRAS_DIR},target=/opt/resolve/Extras \
+     --volume /media/$USER:/media/$USER \
      "${MOUNT_CURSOR_THEME[@]}" \
      "${CGROUP_RULE[@]}" \
      "${MOUNT_SYSTEM_FONTS[@]}" \

--- a/resolve.sh
+++ b/resolve.sh
@@ -250,7 +250,6 @@ set -x
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_MEDIA},target=/opt/resolve/Media \
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_FAIRLIGHT_DIR},target=/opt/resolve/Fairlight \
      --mount type=bind,source=${RESOLVE_MOUNTS_PATH}/${RESOLVE_EXTRAS_DIR},target=/opt/resolve/Extras \
-     --volume /media/$USER:/media/$USER \
      "${MOUNT_CURSOR_THEME[@]}" \
      "${CGROUP_RULE[@]}" \
      "${MOUNT_SYSTEM_FONTS[@]}" \

--- a/resolve.sh
+++ b/resolve.sh
@@ -260,7 +260,3 @@ set -x
      --ipc=host \
      --name="resolve_container" \
      resolve:${RESOLVE_TAG} "$@"
-
-# Removed lines
-#     --device /dev/nvidia0 \
-#     --device /dev/nvidiactl \


### PR DESCRIPTION
This PR documents what I found was necessary in order to install the released Davinci Resolve Studio on my shiny new Ubuntu 20.04 PC. I'm sure I have missed some tricks, and some of it is messy, but it works.

I run it with this shell script:
```sh
#!/bin/bash
rm mounts/logs/rollinglog.txt
xhost +local:docker
RESOLVE_NETWORK=host ./resolve.sh bash -c "export XAUTHORITY=/tmp/.host_Xauthority && exec /opt/resolve/bin/resolve"
```